### PR TITLE
Created and implemented User Playlists endpoint

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -10,6 +10,10 @@ app.use("/static", express.static("public"))
 
 app.use("/user_playlists/:bearer", user_id.get_user_id) // sets res.user_id to the user_id (if the bearer token is valid)
 app.get("/user_playlists/:bearer", user_playlists.get_playlists)
+app.use((error, req, res, next) => {
+    res.status(error.staus || 500)
+    return res.send(error.message)
+})
 
 //export the express app to make it available to other modules
 module.exports = app

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -6,11 +6,13 @@ const user_id = require("./src/get_endpoints/user_id")
 const express = require("express")
 const app = express()
 
-app.use("/static", express.static("public"))
+app.use("/static", express.static("public")) //Anything within the /public directory is delivered statically by accessing /static/filename in your browser
 
 app.use("/user_playlists/:bearer", user_id.get_user_id) // sets res.user_id to the user_id (if the bearer token is valid)
 app.get("/user_playlists/:bearer", user_playlists.get_playlists)
-app.use((error, req, res, next) => {
+
+//Handle any errors
+app.use((error, req, res, next) => { 
     res.status(error.staus || 500)
     return res.send(error.message)
 })

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -1,10 +1,13 @@
 //import and instantiate express
 //import get_playlists from "./src/get_endpoints/user_playlists"
 const recommend_songs = require("./src/get_endpoints/recommend_songs")
+const user_id = require("./src/get_endpoints/user_id")
+const user_playlists = require("./src/get_endpoints/user_playlists")
 const express = require("express")
 const app = express()
 
-// This code disables CORS, it may be necessary for debugging
+// This code disables CORS, it may be necessary for debugging.
+//***We should remove this in the final version***
 app.use((req, res, next) => {
   res.header("Access-Control-Allow-Origin", "YOUR-DOMAIN.TLD"); // update to match the domain you will make the request from
   res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -6,10 +6,17 @@ const user_id = require("./src/get_endpoints/user_id")
 const express = require("express")
 const app = express()
 
+// This code disables CORS, it may be necessary for debugging
+app.use((req, res, next) => {
+  res.header("Access-Control-Allow-Origin", "YOUR-DOMAIN.TLD"); // update to match the domain you will make the request from
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  next();
+});
+
 app.use("/static", express.static("public")) //Anything within the /public directory is delivered statically by accessing /static/filename in your browser
 
-app.use("/user_playlists/:bearer", user_id.get_user_id) // sets res.user_id to the user_id (if the bearer token is valid)
-app.get("/user_playlists/:bearer", user_playlists.get_playlists)
+app.use("/user_playlists/:bearer/:include_tracks", user_id.get_user_id) // sets res.user_id to the user_id (if the bearer token is valid)
+app.get("/user_playlists/:bearer/:include_tracks", user_playlists.get_playlists)
 
 //Handle any errors
 app.use((error, req, res, next) => { 

--- a/back-end/src/get_endpoints/user_id.js
+++ b/back-end/src/get_endpoints/user_id.js
@@ -18,13 +18,13 @@ const get_user_id = (req, res, next) => {
             data = response.data
             req.user_id = data.id
             console.log("Successfully pulled User ID from Spotify API")
-            next()
+            return next()
         })
         .catch((err) => {
             console.log("Something went wrong in the get_user_id endpoint when calling the Spotify API")
             console.error(err)
-            //res.send('error') //Not sure about this error handling
-            return;
+            return next(new Error("Could not pull user ID from Spotify API"))
+
         })
 }
 

--- a/back-end/src/get_endpoints/user_id.js
+++ b/back-end/src/get_endpoints/user_id.js
@@ -17,7 +17,7 @@ const get_user_id = (req, res, next) => {
         .then((response) => {
             data = response.data
             req.user_id = data.id
-            console.log("Successfully pulled User ID from Spotify API")
+            //console.log("Successfully pulled User ID from Spotify API")
             return next()
         })
         .catch((err) => {

--- a/back-end/src/get_endpoints/user_playlists.js
+++ b/back-end/src/get_endpoints/user_playlists.js
@@ -1,10 +1,11 @@
 const axios = require("axios")
 const set_authentication = require("../other/authentication.js").set_authentication
 
-const get_playlists = async (req, res, next) => {
+const get_playlists = async (req, res, next) => { //this function ends up being very slow do to several async calls. Is there a better way?
 
     const bearer = req.params.bearer
-    const user_id = req.user_id //this is set by previous middleware
+    const user_id = req.user_id //this is set by previous middleware in routing
+    const include_tracks = (req.params.include_tracks === "true")
 
     let offset = 0;
     let limit = 50;
@@ -13,13 +14,13 @@ const get_playlists = async (req, res, next) => {
     let data = {}
     let error = null
 
-    if (!user_id)
+    if (!user_id) //check for user_id, which should have been acquired from middleware
     {   
         let msg = "Error: No user_id provided"
         console.log(msg)
         return next(new Error(msg))
     } 
-    if (!set_authentication(bearer, axios))
+    if (!set_authentication(bearer, axios)) //set authentication
     {   
         let msg = "Error: could not run get_playlist due to bad authentication"
         console.log(msg)
@@ -28,12 +29,26 @@ const get_playlists = async (req, res, next) => {
 
     do { //We must make several API calls to cycle through ALL of the user's playlists, as the Spotify API does not allow us to get all at once
     await axios(`https://api.spotify.com/v1/me/playlists?offset=${offset}&limit=${limit}`)
-        .then((response) => {
+        .then(async (response) => {
             data = response.data
 
-            data.items.forEach(item => {
+            const promise = await async_for_each(data.items, async (item, index) => {
                 if (item.owner.id === user_id) //This is owned by the user making the request, so we append it
                 {
+                    if (include_tracks) //append the track contents to the tracks field if indicated
+                    {   
+                        let tracks_items = await get_tracks_items(bearer, item.tracks.href)
+                            
+                        if (!tracks_items) //indicates an error in get_tracks_items()
+                        {
+                            let msg = "Error: could not run get_tracks_items"
+                            error = new Error(msg)
+                            return //this should just escape the await request
+                        } else {
+                            console.log("tracks_items pulled successfully: i = ", index)
+                        }
+                        item.tracks.items = tracks_items
+                    }
                     user_playlists.push(item)
                 } 
             }) //cycle through the playlist JSON objects, which contain additional information
@@ -41,21 +56,59 @@ const get_playlists = async (req, res, next) => {
             total = data.total
             offset += limit
         })
-        .catch((err) => {
+        .catch(async (err) => {
             let msg = "Error: Something went wrong in the get_playlists endpoint when calling the Spotify API"
             console.log(msg)
-            console.err(err)
+            console.error(err)
             error = new Error(msg)
         })
     } while (offset < total && !error) //continue while still in range of the user's playlists, and there is no error
 
-    if (error) //for some reason, this can't be handled inside of the await function, as it results in an infinite loop
+    if (error) //this must be set in the axios function, as returning within the axios function will just return a promise
     {
         return next(error)
     }
 
     console.log("Successfully pulled user playlists from Spotify API")
     return res.send(user_playlists)
+}
+
+const get_tracks_items = async (bearer, url) => {
+    if (!set_authentication(bearer, axios)) //set authentication
+    {   
+        return false
+    }
+
+    let offset = 0
+    let limit = 100
+    let total = 101
+    let error = null
+    let result = []
+
+    //may have to iterate several times, if there are more than 100 items
+    do {
+        await axios(`${url}?offset=${offset}&limit=${limit}`)
+            .then(async (response) => {
+                //console.log("response =", response.data)
+                await async_for_each(response.data.items, (item) => {
+                    result.push(item)
+                })
+                offset += limit
+                total = response.data.total
+            })
+            .catch(async (err) => {
+                error = err
+            })
+        
+    } while (offset < total && !error)
+    //console.log("result = ", result)
+    return result
+}
+
+const async_for_each = async (array, callback) => { // forEach loop in sequential order
+    for (let index = 0; index < array.length; index++) {
+        await callback(array[index], index, array);
+    }
 }
 
 module.exports = {

--- a/back-end/src/get_endpoints/user_playlists.js
+++ b/back-end/src/get_endpoints/user_playlists.js
@@ -44,9 +44,7 @@ const get_playlists = async (req, res, next) => { //this function ends up being 
                             let msg = "Error: could not run get_tracks_items"
                             error = new Error(msg)
                             return //this should just escape the await request
-                        } else {
-                            console.log("tracks_items pulled successfully: i = ", index)
-                        }
+                        } 
                         item.tracks.items = tracks_items
                     }
                     user_playlists.push(item)
@@ -69,7 +67,7 @@ const get_playlists = async (req, res, next) => { //this function ends up being 
         return next(error)
     }
 
-    console.log("Successfully pulled user playlists from Spotify API")
+    //console.log("Successfully pulled user playlists from Spotify API")
     return res.send(user_playlists)
 }
 

--- a/back-end/src/get_endpoints/user_playlists.js
+++ b/back-end/src/get_endpoints/user_playlists.js
@@ -1,7 +1,7 @@
 const axios = require("axios")
 const set_authentication = require("../other/authentication.js").set_authentication
 
-const get_playlists = async (req, res) => {
+const get_playlists = async (req, res, next) => {
 
     const bearer = req.params.bearer
     const user_id = req.user_id //this is set by previous middleware
@@ -11,16 +11,19 @@ const get_playlists = async (req, res) => {
     let total = 51; //total is unknown at start, must be retrieved from API
     let user_playlists = []
     let data = {}
+    let error = null
 
     if (!user_id)
-    {
-        console.log("Error: No user_id provided")
-        return;
+    {   
+        let msg = "Error: No user_id provided"
+        console.log(msg)
+        return next(new Error(msg))
     } 
     if (!set_authentication(bearer, axios))
-    {
-        console.log("Error: could not run get_playlist due to bad authentication")
-        return;
+    {   
+        let msg = "Error: could not run get_playlist due to bad authentication"
+        console.log(msg)
+        return next(new Error(msg))
     }
 
     do { //We must make several API calls to cycle through ALL of the user's playlists, as the Spotify API does not allow us to get all at once
@@ -39,12 +42,17 @@ const get_playlists = async (req, res) => {
             offset += limit
         })
         .catch((err) => {
-            console.log("Error: Something went wrong in the get_playlists endpoint when calling the Spotify API")
-            console.error(err)
-            throw new Error("Something went wrong in the get_playlists endpoint when calling the Spotify API")
-            return;
+            let msg = "Error: Something went wrong in the get_playlists endpoint when calling the Spotify API"
+            console.log(msg)
+            console.err(err)
+            error = new Error(msg)
         })
-    } while (offset < total) //continue while still in range of the user's playlists
+    } while (offset < total && !error) //continue while still in range of the user's playlists, and there is no error
+
+    if (error) //for some reason, this can't be handled inside of the await function, as it results in an infinite loop
+    {
+        return next(error)
+    }
 
     console.log("Successfully pulled user playlists from Spotify API")
     return res.send(user_playlists)

--- a/front-end/src/components/playlistComponent.js
+++ b/front-end/src/components/playlistComponent.js
@@ -10,6 +10,8 @@ import AddIcon from "@material-ui/icons/Add";
 import RemoveIcon from "@material-ui/icons/Remove";
 
 import styles from "../styles/playlistComponentStyles.js";
+import {get_bearer, set_authentication} from "../components/authentication"
+import axios from "axios"
 
 const pressButton = (event, added, setAdded) => {
   event.stopPropagation(); //Prevents dropdown from opening when button is pressed
@@ -29,8 +31,22 @@ const Playlist = (props) => {
   } else {
     buttonIcon = <RemoveIcon color="secondary" />;
   }
+    set_authentication(localStorage, axios)
+    let tracks
 
-  console.log("playlist name: ", playlist.name);
+    console.log("href = " , playlist.tracks)
+    axios(playlist.tracks.href)
+        .then((response) => {
+            tracks = response.data
+        })
+        .catch((err) => {
+            console.log("Error retrieving playlist tracks")
+            console.error(err)
+            return
+        })
+
+  console.log("playlist: ", playlist);
+  console.log("tracks: ", tracks)
   return (
     <Accordion>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
@@ -39,7 +55,7 @@ const Playlist = (props) => {
             {/*This should be the playlist image pulled from Spotify*/}
             <img
               className={classes.playlistImage}
-              src={playlist.images[0].url}
+              src={playlist.images[0]}
               alt="playlist"
             />
           </div>
@@ -59,7 +75,7 @@ const Playlist = (props) => {
       <Divider />
       <AccordionDetails className={classes.accordionDetails}>
         <div className={classes.tracklistContainer}>
-          {playlist.tracks.items.map((curSong) => (
+          {tracks.items.map((curSong) => (
             <Song classes={classes} song={curSong} /> //Creates a song card for each song in the playlist
           ))}
         </div>

--- a/front-end/src/components/playlistComponent.js
+++ b/front-end/src/components/playlistComponent.js
@@ -32,8 +32,9 @@ const Playlist = (props) => {
     buttonIcon = <RemoveIcon color="secondary" />;
   }
     set_authentication(localStorage, axios)
-    let tracks
+    let tracks = playlist.tracks
 
+    /*
     console.log("href = " , playlist.tracks)
     axios(playlist.tracks.href)
         .then((response) => {
@@ -44,9 +45,16 @@ const Playlist = (props) => {
             console.error(err)
             return
         })
-
+    */
   console.log("playlist: ", playlist);
   console.log("tracks: ", tracks)
+  console.log("tracks.items:" )
+  if (tracks.items)
+  {
+    tracks.items.forEach((item) => {
+        console.log(item)
+    })
+  }
   return (
     <Accordion>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
@@ -55,7 +63,7 @@ const Playlist = (props) => {
             {/*This should be the playlist image pulled from Spotify*/}
             <img
               className={classes.playlistImage}
-              src={playlist.images[0]}
+              src={playlist.images[0].url}
               alt="playlist"
             />
           </div>
@@ -73,19 +81,21 @@ const Playlist = (props) => {
         </div>
       </AccordionSummary>
       <Divider />
-      <AccordionDetails className={classes.accordionDetails}>
-        <div className={classes.tracklistContainer}>
-          {tracks.items.map((curSong) => (
-            <Song classes={classes} song={curSong} /> //Creates a song card for each song in the playlist
-          ))}
-        </div>
-      </AccordionDetails>
+      {tracks.items &&
+        <AccordionDetails className={classes.accordionDetails}>
+          <div className={classes.tracklistContainer}>
+            {tracks.items.map((curSong) => (
+              <Song classes={classes} song={curSong} /> //Creates a song card for each song in the playlist
+            ))}
+          </div>
+        </AccordionDetails>
+      }
     </Accordion>
   );
 };
 
 const Song = (props) => {
-  const song = props.song;
+  const song = props.song.track;
   const classes = props.classes;
   return (
     <Card className={classes.songCard} variant="square">

--- a/front-end/src/pages/addMyMusic.js
+++ b/front-end/src/pages/addMyMusic.js
@@ -44,6 +44,8 @@ const AddMyMusic = (props) => {
 
     useEffect(() => {
         console.log("fetching playlists");
+
+        //make call for playlists without track contents
         axios({
             method: "get",
             url: `http://localhost:5000/user_playlists/${get_bearer(localStorage)}/false` //true indicates we want playlists attached
@@ -89,8 +91,6 @@ const AddMyMusic = (props) => {
                 console.log("error encountered making request to user_playlists endpoint")
                 console.error(err);
                 console.log(err)
-
-                
 
                 if (playlists === "unset") 
                 {   setPlaylists(backupPlaylists);

--- a/front-end/src/pages/addMyMusic.js
+++ b/front-end/src/pages/addMyMusic.js
@@ -6,6 +6,7 @@ import Button from "@material-ui/core/Button";
 import ArrowBackIosIcon from "@material-ui/icons/ArrowBackIos";
 import { Typography } from "@material-ui/core";
 import axios from "axios";
+import {get_bearer, set_authentication} from "../components/authentication"
 
 // import backgroundWhite from "../media/background_white.png";
 
@@ -15,45 +16,48 @@ import Playlist from "../components/playlistComponent.js";
 import styles from "../styles/addMyMusicStyles.js";
 
 const AddMyMusic = (props) => {
-  const [playlists, setPlaylists] = useState([]);
-  let history = useHistory();
-  const { classes } = props;
-  const [uiLoading, setuiLoading] = useState(true);
+    const [playlists, setPlaylists] = useState([]);
+    let history = useHistory();
+    const { classes } = props;
+    const [uiLoading, setuiLoading] = useState(true);
 
-  useEffect(() => {
-    setuiLoading(false);
-    console.log("fetching 10 playlists");
+    useEffect(() => {
+        console.log("fetching playlists");
+        axios({
+            method: "get",
+            url: `http://localhost:5000/user_playlists_with_songs/${get_bearer(localStorage)}`
+        }) //makes a call to the back-end
+            .then((response) => {  
+                console.log(response.data)
+                console.log(playlists);
+                setPlaylists(response.data); //stores the result from the api call in playlists
+                setuiLoading(false);
+            })
+            .catch((err) => {
+                console.log("error encountered making request to user_playlists endpoint")
+                console.error(err);
+                console.log(err)
 
-    axios("https://my.api.mockaroo.com/playlist.json?key=032af9d0") //makes a call to the mock api
-      .then((response) => {
-        setPlaylists(response.data); //stores the result from the api call in playlists
-        console.log(playlists);
-      })
-      .catch((err) => {
-        console.log(
-          "Something went wrong, perhaps you reached your limit for API requests?"
-        );
-        console.error(err);
+                const backupPlaylists = [
+                {
+                    name: "My Playlist",
+                    images: {
+                    url:
+                        "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi1.wp.com%2Fwww.gardeningknowhow.com%2Fwp-content%2Fuploads%2F2017%2F01%2Fprune-mock-orange.jpg%3Ffit%3D1254%252C836%26ssl%3D1&f=1&nofb=1",
+                    },
+                    tracks: {
+                    items: [
+                        { artists: [{ name: "Jack" }], name: "Good Song" },
+                        { artists: [{ name: "Jill" }], name: "The Hill" },
+                    ],
+                    },
+                },
+                ];
 
-        const backupPlaylists = [
-          {
-            name: "My Playlist",
-            images: {
-              url:
-                "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi1.wp.com%2Fwww.gardeningknowhow.com%2Fwp-content%2Fuploads%2F2017%2F01%2Fprune-mock-orange.jpg%3Ffit%3D1254%252C836%26ssl%3D1&f=1&nofb=1",
-            },
-            tracks: {
-              items: [
-                { artists: [{ name: "Jack" }], name: "Good Song" },
-                { artists: [{ name: "Jill" }], name: "The Hill" },
-              ],
-            },
-          },
-        ];
-
-        setPlaylists(backupPlaylists);
-      });
-  }, []); //only run once
+                setPlaylists(backupPlaylists);
+                setuiLoading(false)
+            });
+    }, []); //only run once
 
   if (uiLoading === true) {
     return <Loading />; //If still waiting for an api request to return, will show the loading screen instead

--- a/front-end/src/pages/landing.js
+++ b/front-end/src/pages/landing.js
@@ -62,10 +62,12 @@ const Landing = (props) => {
   }, []);
 
   const handleSpotifyRedirect = () => {
-    window.location = `${REACT_APP_AUTHORIZE_URL}?client_id=${REACT_APP_CLIENT_ID}&redirect_uri=${REACT_APP_REDIRECT_URL}&response_type=token&show_dialog=true`;
-    // setSpotifyRedirect(true);
+    let scopes =
+      "user-read-private user-read-email user-read-playback-state playlist-read-collaborative playlist-read-private user-modify-playback-state user-read-currently-playing playlist-modify-private";
+    window.location = `${REACT_APP_AUTHORIZE_URL}?client_id=${REACT_APP_CLIENT_ID}${
+      scopes ? "&scope=" + encodeURIComponent(scopes) : ""
+    }&redirect_uri=${REACT_APP_REDIRECT_URL}&response_type=token&show_dialog=true`; // setSpotifyRedirect(true);
   };
-
   const handleGuestRedirect = () => {
     setGuestRedirect(true);
   };


### PR DESCRIPTION
Closes #89

Created a user_playlists endpoint on the back-end, and integrated it in the addMyMusic page on the front-end.
The user_playlists endpoint can be reached via localhost:5000/user_playlists/<bearer_token>/<include_tracks>
<include_tracks> should be either "true" or "false", and indicates if you want the request to return all the tracks within in the playlist in the response.

Make sure to enable CORS when testing this. It allows you to make requests between different localhost instances. I am using [this firefox extension](https://addons.mozilla.org/en-US/firefox/addon/access-control-allow-origin/), and [here is the equivalent chrome extension](https://chrome.google.com/webstore/detail/allow-cors-access-control/lhobafahddgcelffkeicbaginigeejlf)
(Make sure to press the button to toggle it on within the extension, its kind of hard to notice but its on the left)

Admittedly, there are some problems with this pull request. For instance, the way the back-end endpoint pulls tracks from the Spotify API involves many requests, and sometimes the Spotify API considers this throttling and throws a 429 error. Additionally, the request that asks for the track contents can be quite slow, and thus it may take a while for all the contents to load on the page (can be ~15 seconds). To work around this, the front-end makes a request just for the playlist names and images first, and then a request for all the details. The prior request will load very quickly, but you may have to wait a while to see the actual contents of each playlist. 

That said, I believe it a priority we get the back-end done before fixing these issues. I will open up a task however detailing the problems as a stretch goal.