### PR TITLE
Added remove from pool endpoint to back-end

### DIFF
--- a/back-end/helper_methods/is_owner.js
+++ b/back-end/helper_methods/is_owner.js
@@ -1,0 +1,32 @@
+let Group = require("../models/groups.model");
+
+const is_owner = async (user_id, group_id) => {
+  let owners 
+
+  let error = await Group.findOne({_id:group_id})
+    .then(res => {
+      owners = res.owners
+      return false
+    })
+    .catch(err => {
+      console.log(err)
+      return new Error(err)
+    })
+
+  if (error)
+  {
+    return error
+  }
+
+  // if the user is not in the owners array, return false
+  if (!owners.includes(user_id))
+  {
+    return false
+  }
+
+  return true
+}
+
+module.exports = {
+  is_owner: is_owner
+}

--- a/back-end/requests/delete/remove_from_pool.js
+++ b/back-end/requests/delete/remove_from_pool.js
@@ -1,0 +1,94 @@
+const axios = require("axios")
+let Group = require("../../models/groups.model");
+const set_authentication = require("../other/authentication.js").set_authentication
+const is_in_group = require("../../helper_methods/is_in_group.js").is_in_group
+const is_valid_playlist =  require("../../helper_methods/is_valid_playlist.js").is_valid_playlist
+const playlist_is_in_pool = require("../../helper_methods/playlist_is_in_pool").playlist_is_in_pool
+let is_owner = require("../../helper_methods/is_owner").is_owner
+
+const remove_from_pool = async (req, res, next) => {
+  const bearer = req.params.bearer
+  const group_id = req.params.group_id
+  const playlist_id = req.params.playlist_id.trim() //trim any whitespace
+  const user_id = req.user_id
+
+  //check that the user is valid
+  let in_group = await is_in_group(user_id, group_id);
+  if (in_group instanceof Error) {
+    console.log(
+      "Error: user is not in group, or error encountered in is_in_group method (perhaps in an invalid group id)"
+    );
+    return next(in_group);
+  }
+
+  //check if the user is the owner (then they can delete any playlist)
+  let owner = await is_owner(user_id, group_id)
+  if (owner instanceof Error)
+  {
+    return next(owner)
+  }
+
+  //check if the user has permission to delete the playlist (they added it or are an owner)
+  let pool
+  let error = await Group.findOne({_id:group_id})
+    .then(res => {
+      pool = res.pool
+      return false
+    })
+    .catch(err => {
+      console.log(err)
+      return new Error(err)
+    })
+
+  if (error)
+  {
+    return next(error)
+  }
+
+  let element = null
+  let index = null
+  for (let i = 0; i < pool.length; i++)
+  {
+    let cur_element = pool[i]
+    if (cur_element.playlist_id === playlist_id)
+    {
+      element = cur_element
+      index = i
+    }
+  }
+
+  if (!element)
+  {
+    const msg = "Error: playlist not found in pool"
+    console.log(msg)
+    return next(new Error(msg))
+  }
+  if (!owner && element.added_by !== user_id)
+  {
+    const msg = "Error: invalid permissions, user cannot remove this playlist from pool"
+    console.log(msg)
+    return next(new Error(msg))
+  } 
+  //delete the playlist
+
+  error = await Group.updateOne({_id:group_id},
+    { $pull: {pool: {playlist_id: playlist_id} } }
+  )
+    .then(res => {
+      return false
+    })
+    .catch(err => {
+      return new Error(err)
+    })
+
+  if (error)
+  {
+    return error
+  }
+  
+  res.send("Playlist remove successfully from pool")
+}
+
+module.exports = {
+  remove_from_pool: remove_from_pool
+}

--- a/back-end/requests/other/authentication.js
+++ b/back-end/requests/other/authentication.js
@@ -5,7 +5,7 @@ const set_authentication = (bearer_token, axios) => {
       ] = `Bearer ${bearer_token}`;
       return true //indicates success
     } else {
-        console.log("Error: Invalid bearer token or axios passed to set_authentication in the back-end")
+        console.log("Error: Perhaps no bearer token was passed to set_authentication in the back-end")
         return false //indicates failure
     }
   }

--- a/back-end/requests/put/add_to_pool.js
+++ b/back-end/requests/put/add_to_pool.js
@@ -8,7 +8,7 @@ const playlist_is_in_pool = require("../../helper_methods/playlist_is_in_pool").
 const add_to_pool = async (req, res, next) => {
   const group_id = req.params.group_id;
   const bearer = req.params.bearer;
-  const playlist_id = req.params.playlist_id;
+  const playlist_id = req.params.playlist_id.trim() //trim any whitespace
   const user_id = req.user_id;
 
   //check that playlist_href is valid

--- a/back-end/routes/groups.js
+++ b/back-end/routes/groups.js
@@ -1,6 +1,7 @@
 const router = require("express").Router();
 let Group = require("../models/groups.model");
 const add_to_pool = require("../requests/put/add_to_pool");
+const remove_from_pool = require("../requests/delete/remove_from_pool")
 const user_id = require("../requests/get/user_id");
 const add_members = require("../requests/put/add_members");
 const add_to_ban = require("../requests/put/add_to_ban");
@@ -43,11 +44,16 @@ router.route("/add").post((req, res) => {
     .catch((err) => res.status(400).json("Error: " + err));
 });
 
+//get user id, and set it for any routes which require it
 router.use("/add_to_pool/:group_id/:playlist_id/:bearer", user_id.get_user_id);
+router.use("/remove_from_pool/:group_id/:playlist_id/:bearer", user_id.get_user_id)
+
 router.put(
   "/add_to_pool/:group_id/:playlist_id/:bearer",
   add_to_pool.add_to_pool
 );
+
+router.delete("/remove_from_pool/:group_id/:playlist_id/:bearer", remove_from_pool.remove_from_pool)
 
 
 router.put("/add_members/:group_id/:user_id", add_members.add_members)

--- a/back-end/test/add_to_pool.js
+++ b/back-end/test/add_to_pool.js
@@ -1,0 +1,129 @@
+// Make sure the back-end is running when running tests. use the command 'npm run test --bearer=<bearer_token>' to
+// run tests. If you have any trouble, please let me know - Ryan
+
+const assert = require('chai').assert
+const axios = require("axios")
+let Group = require("../models/groups.model");
+const is_in_group = require('../helper_methods/is_in_group.js').is_in_group
+const is_valid_playlist = require('../helper_methods/is_valid_playlist').is_valid_playlist
+const mongoose = require("mongoose");
+const set_authentication = require("../requests/other/authentication").set_authentication
+
+const run_add_to_pool_tests = async bearer => {
+ //Testing for add_to_pool endpoint
+  describe('add to pool (and related methods)', async () => {
+    //create a group for testing purposes
+    before(async () => {
+      //connect to MongoDB
+      const uri = process.env.ATLAS_URI;
+      await mongoose.connect(uri, {
+        keepAlive: true,
+        useNewUrlParser: true,
+        useCreateIndex: true,
+        useUnifiedTopology: true,
+      });
+
+      //create a test group
+      const members = ["rbx2co", "jonoto", "123milkman"]
+      const banned_members = ["jonoto"]
+      const owners = ["rbx2co"]
+      const id = ""
+      const pool = []
+      const group = new Group({banned_members: banned_members, members: members, owners: owners, id: id, pool: pool}) //this MUST correspond to the order specified in the schema
+      await group.save()
+        .then(res => {
+          console.log("test group saved successfully!")
+          group_id = group._id
+        })
+        .catch(err => {
+          console.log(err)
+          console.log("error encountered saving test group, this may cause test failures")
+        })
+    })
+
+    describe("is_in_group tests", async () => {
+      it("Group id is an object", () => {
+        assert.typeOf(group_id, "object")
+      })
+
+      it("'rbx2co' is in group", async () => {
+        let in_group = await is_in_group("rbx2co", group_id)
+        assert.isTrue(in_group)
+      })
+
+      it("'jonoto' is not in group (banned user)", async () => {
+        let in_group = await is_in_group("jonoto", group_id) //this should return an error
+        assert.isTrue(in_group instanceof Error)
+      })
+
+      it("'shelly15' is not in group", async () => {
+        let in_group = await is_in_group("shelly15", group_id)  //this should return an error
+        assert.isTrue(in_group instanceof Error)
+      })
+    })
+
+    describe("is_valid_playlist tests", async () => {
+      it("valid playlist is valid", async () =>{  //note, as this is hardcoded, if the playlist is deleted this test will fail! I don't plan on deleting it, but I ever do accidentally, please change the playlist id here
+        const playlist_id = "3PLPVWNT4CMjqSLpoRThxf"
+        let is_valid = await is_valid_playlist(bearer, playlist_id)
+        assert.isTrue(is_valid)
+      })
+
+      it("123 is invalid playlist", async () => {
+        const playlist_id = "123"
+        let is_valid = await is_valid_playlist(bearer, playlist_id)
+        assert.isFalse(is_valid)
+      })
+    })
+
+    describe("add_to_pool tests", async () => {
+      it('can add to pool', async () => {
+        const playlist_id = "3PLPVWNT4CMjqSLpoRThxf" //note, as this is hardcoded, if the playlist is deleted this test will fail! I don't plan on deleting it, but I ever do accidentally, please change the playlist id here
+        let status_code
+        let passed = await axios.put(`http://localhost:5000/groups/add_to_pool/${group_id}/${playlist_id}/${bearer}`) 
+          .then((res) => {
+            status_code = res.status
+          })
+          .catch(err => {
+            //status_code = err.status
+            console.log(err)
+          })
+        
+        assert.strictEqual(status_code, 200) //indicates success
+      })
+
+      it('can not add the same playlist twice', async () => {
+        const playlist_id = "3PLPVWNT4CMjqSLpoRThxf" //note, as this is hardcoded, if the playlist is deleted this test will fail! I don't plan on deleting it, but I ever do accidentally, please change the playlist id here
+        let status_code
+
+        let passed = await axios.put(`http://localhost:5000/groups/add_to_pool/${group_id}/${playlist_id}/${bearer}`) 
+          .then((res) => {
+            status_code = res.status
+            return true
+          })
+          .catch(err => {
+            //console.log(err.message)
+            return false
+          })
+        
+        assert.isFalse(passed) //In this case, we desire failure
+      })
+    })
+    
+    //delete the temporary group we've created for the sake of these tests
+    after(async () => {
+      Group.deleteOne({_id: group_id})
+        .then(() => {
+          console.log("deleted group successfully!")
+        })
+        .catch((err) => {
+          console.log("Error: could not delete group created for these tests")
+          console.log(err)
+        })
+    })
+  })
+}
+
+module.exports = {
+  run_add_to_pool_tests: run_add_to_pool_tests
+}

--- a/back-end/test/index.js
+++ b/back-end/test/index.js
@@ -21,6 +21,8 @@ if (!bearer)
   console.log("No bearer specified (specify using --bearer=<bearer_token>). Aborting.")
   return
 }
+
+//Run the add to pool and remove from pool tests
 run_add_to_pool_tests(bearer)
 
 //create a group for testing purposes

--- a/back-end/test/index.js
+++ b/back-end/test/index.js
@@ -1,132 +1,42 @@
-// Make sure the back-end is running when running tests. use the command 'npm run test --bearer=<bearer_token>' to
-// run tests. If you have any trouble, please let me know - Ryan
-
 const assert = require('chai').assert
 const axios = require("axios")
 let Group = require("../models/groups.model");
 const is_in_group = require('../helper_methods/is_in_group.js').is_in_group
 const is_valid_playlist = require('../helper_methods/is_valid_playlist').is_valid_playlist
 const mongoose = require("mongoose");
+const run_add_to_pool_tests = require("./add_to_pool.js").run_add_to_pool_tests
+const set_authentication = require("../requests/other/authentication").set_authentication
+
 
 require("dotenv").config();
 
 const bearer = process.env.npm_config_bearer
 if (!bearer)
 {
-  console.log("Warning: No bearer specified! Some tests may fail as a result")
+  console.log("No bearer specified (specify using --bearer=<bearer_token>). Aborting.")
+  return
 }
 
-//create a group for testing purposes
-let group_id
+run_add_to_pool_tests(bearer)
 
-//Testing for add_to_pool endpoint
-describe('add to pool (and related methods)', async () => {
-  before(async () => {
-    //connect to MongoDB
-    const uri = process.env.ATLAS_URI;
-    await mongoose.connect(uri, {
-      keepAlive: true,
-      useNewUrlParser: true,
-      useCreateIndex: true,
-      useUnifiedTopology: true,
-    });
+// const begin_tests = async (bearer => {
+//   //check for a valid bearer token
+//   set_authentication(bearer, axios)
 
-    //create a test group
-    const members = ["rbx2co", "jonoto", "123milkman"]
-    const banned_members = ["jonoto"]
-    const owners = ["rbx2co"]
-    const id = ""
-    const pool = []
-    const group = new Group({banned_members: banned_members, members: members, owners: owners, id: id, pool: pool}) //this MUST correspond to the order specified in the schema
-    await group.save()
-      .then(res => {
-        console.log("test group saved successfully!")
-        group_id = group._id
-      })
-      .catch(err => {
-        console.log(err)
-        console.log("error encountered saving test group, this may cause test failures")
-      })
-  })
+//   const valid = await axios('https://api.spotify.com/v1/me')
+//   .then(res => {
+//     return true
+//   })
+//   .catch(err => {
+//     return false
+//   })
 
-  describe("is_in_group tests", async () => {
-    it("Group id is an object", () => {
-      assert.typeOf(group_id, "object")
-    })
+//   if (!valid)
+//   {
+//     console.log("Was unable to get user's profile, Bearer token is most likely invalid. Aborting.")
+//     return
+//   }
 
-    it("'rbx2co' is in group", async () => {
-      let in_group = await is_in_group("rbx2co", group_id)
-      assert.isTrue(in_group)
-    })
 
-    it("'jonoto' is not in group (banned user)", async () => {
-      let in_group = await is_in_group("jonoto", group_id) //this should return an error
-      assert.isTrue(in_group instanceof Error)
-    })
-
-    it("'shelly15' is not in group", async () => {
-      let in_group = await is_in_group("shelly15", group_id)  //this should return an error
-      assert.isTrue(in_group instanceof Error)
-    })
-  })
-
-  describe("is_valid_playlist tests", async () => {
-    it("valid playlist is valid", async () =>{  //note, as this is hardcoded, if the playlist is deleted this test will fail! I don't plan on deleting it, but I ever do accidentally, please change the playlist id here
-      const playlist_id = "3PLPVWNT4CMjqSLpoRThxf"
-      let is_valid = await is_valid_playlist(bearer, playlist_id)
-      assert.isTrue(is_valid)
-    })
-
-    it("123 is invalid playlist", async () => {
-      const playlist_id = "123"
-      let is_valid = await is_valid_playlist(bearer, playlist_id)
-      assert.isFalse(is_valid)
-    })
-  })
-
-  describe("add_to_pool tests", async () => {
-    it('can add to pool', async () => {
-      const playlist_id = "3PLPVWNT4CMjqSLpoRThxf" //note, as this is hardcoded, if the playlist is deleted this test will fail! I don't plan on deleting it, but I ever do accidentally, please change the playlist id here
-      let status_code
-      let passed = await axios.put(`http://localhost:5000/groups/add_to_pool/${group_id}/${playlist_id}/${bearer}`) 
-        .then((res) => {
-          status_code = res.status
-        })
-        .catch(err => {
-          //status_code = err.status
-          console.log(err)
-        })
-      
-      assert.strictEqual(status_code, 200) //indicates success
-    })
-
-    it('can not add the same playlist twice', async () => {
-      const playlist_id = "3PLPVWNT4CMjqSLpoRThxf" //note, as this is hardcoded, if the playlist is deleted this test will fail! I don't plan on deleting it, but I ever do accidentally, please change the playlist id here
-      let status_code
-
-      let passed = await axios.put(`http://localhost:5000/groups/add_to_pool/${group_id}/${playlist_id}/${bearer}`) 
-        .then((res) => {
-          status_code = res.status
-          return true
-        })
-        .catch(err => {
-          //console.log(err.message)
-          return false
-        })
-      
-      assert.isFalse(passed) //In this case, we desire failure
-    })
-  })
-  
-  //delete the temporary group we've created for the sake of these tests
-  after(async () => {
-    Group.deleteOne({_id: group_id})
-      .then(() => {
-        console.log("deleted group successfully!")
-      })
-      .catch((err) => {
-        console.log("Error: could not delete group created for these tests")
-        console.log(err)
-      })
-  })
-})
+//   return
+// })


### PR DESCRIPTION
Added the remove from pool endpoint to the back-end along with corresponding tests. You can run the tests with `npm run test --bearer=<bearer_token>` within the back-end directory, while the back-end itself is running. To test the endpoint directly, use the uri localhost:5000/groups/remove_from_pool/:group_id/:playlist_id/:bearer