### PR TITLE
Added "remove from pool" functionality to "/addMyMusic" on the front-end. Fixed a bug in generate_playlist

### DIFF
--- a/back-end/requests/post/generate_playlist.js
+++ b/back-end/requests/post/generate_playlist.js
@@ -77,6 +77,13 @@ const generate_playlist = async (req, res, next) => {
 
     let user_arrays = get_user_arrays(playlists)
 
+    if (empty_user_arrays(user_arrays))
+    {
+        const msg = "Error: no songs inside of any of the users' playlists"
+        //console.log(msg)
+        return next(new Error(msg))
+    }
+
     let occurrences = get_occurrences(user_arrays)
 
     let uris = [] //should be an array of track uri's (spotify:track:${track_id})
@@ -191,6 +198,21 @@ const get_user_arrays = (playlists) => { //gets an object of user arrays, each c
     })
 
     return user_songs
+}
+
+const empty_user_arrays = (user_arrays) => { //returns true if no songs are in any of the user arrays
+    let result = true
+    
+    Object.keys(user_arrays).forEach(user_id => {
+        let user_array = user_arrays[user_id]
+        //console.log("user_array = ", user_array)
+        if (user_array.length > 0)
+        {   
+            result = false
+        }
+    })
+
+    return result
 }
 
 const get_occurrences = (user_arrays) => { //gets an object of the format {song_occurrences: [], artist_occurrences: []}

--- a/front-end/src/components/playlistComponent.js
+++ b/front-end/src/components/playlistComponent.js
@@ -13,6 +13,17 @@ import styles from "../styles/playlistComponentStyles.js";
 import {get_bearer, set_authentication} from "../components/authentication"
 import axios from "axios"
 
+const pool_has_playlist = (pool, playlist_id) => {
+  for (let i = 0; i < pool.length; i++)
+  {
+    if (pool[i].playlist_id === playlist_id) //playlist was added by the current user to the pool already
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
 const pressButton = (event, added, setAdded, playlist, group_id) => {
   event.stopPropagation(); //Prevents dropdown from opening when button is pressed
   const playlist_id = playlist.id
@@ -42,8 +53,10 @@ const pressButton = (event, added, setAdded, playlist, group_id) => {
 const Playlist = (props) => {
   const playlist = props.playlist;
   const group_id = props.group_id
+  const pool = props.pool
   const { classes } = props;
-  const [added, setAdded] = useState(false); //keeps track of whether the playlist has been added to the pool or not.
+  let addedAtLoad = pool_has_playlist(pool, playlist.id)
+  const [added, setAdded] = useState(addedAtLoad); //keeps track of whether the playlist has been added to the pool or not.
   let buttonIcon;
 
   if (!added) {

--- a/front-end/src/components/playlistComponent.js
+++ b/front-end/src/components/playlistComponent.js
@@ -24,7 +24,12 @@ const pool_has_playlist = (pool, playlist_id) => {
   return false;
 }
 
-const pressButton = (event, added, setAdded, playlist, group_id) => {
+const pressButton = (event, added, setAdded, playlist, group_id, buttonEnabled, setButtonEnabled) => {
+  if (!buttonEnabled)
+  {
+    return
+  }
+  setButtonEnabled(false)
   event.stopPropagation(); //Prevents dropdown from opening when button is pressed
   const playlist_id = playlist.id
   if (!added)
@@ -33,19 +38,32 @@ const pressButton = (event, added, setAdded, playlist, group_id) => {
       {
         method: "put",
         url: `http://localhost:5000/groups/add_to_pool/${group_id}/${playlist_id}/${get_bearer(localStorage)}`,
-        
       }
     )
       .then(res => {
         setAdded(true);
+        setButtonEnabled(true)
       })
       .catch(err => {
         console.log(err)
         console.log("Error encountered adding the playlist to the group")
+        setButtonEnabled(true)
       })
   } else {
     //should actually remove the group
-    setAdded(false);
+    axios({
+      method: "delete",
+      url: `http://localhost:5000/groups/remove_from_pool/${group_id}/${playlist_id}/${get_bearer(localStorage)}`
+    })
+      .then(res => {
+        setAdded(false);
+        setButtonEnabled(true)
+      })
+      .catch(err => {
+        console.log(err)
+        console.log("Error encountered removing the playlist from the group")
+        setButtonEnabled(true)
+      })
   }
   //In a later sprint (2 or 3), we should also actually add the playlist to the pool
 };
@@ -57,6 +75,7 @@ const Playlist = (props) => {
   const { classes } = props;
   let addedAtLoad = pool_has_playlist(pool, playlist.id)
   const [added, setAdded] = useState(addedAtLoad); //keeps track of whether the playlist has been added to the pool or not.
+  const [buttonEnabled, setButtonEnabled] = useState(true)
   let buttonIcon;
 
   if (!added) {
@@ -101,7 +120,7 @@ const Playlist = (props) => {
             className={classes.button}
             color="primary"
             onFocus={(event) => event.stopPropagation()}
-            onClick={(event) => pressButton(event, added, setAdded, playlist, group_id)}
+            onClick={(event) => pressButton(event, added, setAdded, playlist, group_id, buttonEnabled, setButtonEnabled)}
           >
             {buttonIcon}
           </IconButton>

--- a/front-end/src/pages/addMyMusic.js
+++ b/front-end/src/pages/addMyMusic.js
@@ -36,8 +36,16 @@ const backupPlaylists = [
     },
 ];
 
+const backupPool = [
+  {
+    added_by: "nobody",
+    playlist_id: "12345"
+  }
+]
+
 const AddMyMusic = (props) => {
   const [playlists, setPlaylists] = useState("unset");
+  const [pool, setPool] = useState(null)
   let history = useHistory();
   let location = useLocation()
   let state = location.state
@@ -73,19 +81,31 @@ const AddMyMusic = (props) => {
   
 
         //make call for playlists without track contents
+        let bearer = get_bearer(localStorage)
         axios({
             method: "get",
-            url: `http://localhost:5000/user_playlists/${get_bearer(localStorage)}/false` //true indicates we want playlists attached
+            url: `http://localhost:5000/user_playlists/${bearer}/false` //true indicates we want playlists attached
         }) //makes a call to the back-end
             .then((response) => {  
-                console.log(response.data)
-                
-            
                 if (playlists === "unset")
                 {
                   setPlaylists(response.data); //stores the result from the api call in playlists
-                  //console.log("playlists=", playlists);
-                  setuiLoading(false);
+                  //get and set the pool
+                  axios({
+                    method: "get",
+                    url: `http://localhost:5000/groups/get_pool/${group_id}/${bearer}`
+                  })
+                    .then(poolRes => {
+                      console.log("poolRes = ", poolRes)
+                      setPool(poolRes.data.pool);
+                      setuiLoading(false);
+                    })
+                    .catch(err => {
+                      console.log("Error: Could not get pool")
+                      console.error(err)
+                      setPool(backupPool)
+                      setuiLoading(false)
+                    })
                 }
             })
             .catch((err) => {
@@ -96,6 +116,7 @@ const AddMyMusic = (props) => {
                 if (playlists === "unset")
                 {
                     setPlaylists(backupPlaylists);
+                    setPool(backupPool)
                     setuiLoading(false)
                 }
             });
@@ -140,7 +161,7 @@ const AddMyMusic = (props) => {
           </AppBar>
           <div className={classes.playlistContainer}>
             {playlists.map((item) => (
-              <Playlist playlist={item} group_id={group_id} has_tracks={haveTracks}></Playlist>
+              <Playlist playlist={item} pool={pool} group_id={group_id} has_tracks={haveTracks}></Playlist>
             ))}
           </div>
         </Container>

--- a/front-end/src/pages/addMyMusic.js
+++ b/front-end/src/pages/addMyMusic.js
@@ -95,8 +95,7 @@ const AddMyMusic = (props) => {
                     method: "get",
                     url: `http://localhost:5000/groups/get_pool/${group_id}/${bearer}`
                   })
-                    .then(poolRes => {
-                      console.log("poolRes = ", poolRes)
+                    .then(poolRes => { 
                       setPool(poolRes.data.pool);
                       setuiLoading(false);
                     })


### PR DESCRIPTION
You can now remove your own songs from the pool (but only from the /addMyMusic page). 

Keep in mind the addMyMusic page requires an allow CORS extension enabled to work for whatever reason. 

Also, I made a change to the generate playlist function. Basically, if you tried to generate a playlist where every playlist in the pool was empty, it was causing the back-end to crash, so I added a check for this.