### PR TITLE
Can now view generated playlist on the front-end. 

### DIFF
--- a/back-end/requests/get/get_generated_playlist.js
+++ b/back-end/requests/get/get_generated_playlist.js
@@ -71,8 +71,8 @@ const get_generated_playlist = async (req, res, next) => {
         curated_track.id = track.track.id
         curated_tracks.push(curated_track)
     })
-
-    res.send(curated_tracks)
+    
+    res.json({songs: curated_tracks})
 }
 
 module.exports = {

--- a/back-end/requests/get/get_generated_playlist.js
+++ b/back-end/requests/get/get_generated_playlist.js
@@ -58,7 +58,21 @@ const get_generated_playlist = async (req, res, next) => {
         return next(error)
     }
     
-    res.send(tracks)
+    let curated_tracks = [] //strip any unecessary information for sake of front-end
+    tracks.forEach(track => {
+        let curated_track = {}
+        curated_track.title = track.track.name
+        if (!track.track.artists[0]) //no artist info available
+        {
+            curated_track.artist = "Unknown"
+        } else {
+        curated_track.artist = track.track.artists[0].name
+        }
+        curated_track.id = track.track.id
+        curated_tracks.push(curated_track)
+    })
+
+    res.send(curated_tracks)
 }
 
 module.exports = {

--- a/back-end/requests/get/get_generated_playlist.js
+++ b/back-end/requests/get/get_generated_playlist.js
@@ -13,7 +13,7 @@ const get_generated_playlist = async (req, res, next) => {
         .then(res => {
             members = res.members
             playlist_is_generated = res.playlist_is_generated
-            playlist_id = res.playlist_id
+            playlist_id = res.generated_playlist_id
             return false
         })
         .catch(err => {
@@ -27,8 +27,38 @@ const get_generated_playlist = async (req, res, next) => {
     {
         return next(error)
     }
+
+    if (!playlist_is_generated)
+    {
+        const msg = "Error: playlist is yet to be generated"
+        return next(new Error(msg))
+    }
+
+    if (!members.includes(user_id))
+    {
+        const msg = "Error: user not in group"
+        return next(new Error(msg))
+    }
+
+    //get the generated playlist's tracks from spotify
+
+    let tracks
+    error = await axios(`https://api.spotify.com/v1/playlists/${playlist_id}/tracks`)
+        .then(res => {
+            tracks = res.data.items
+        })
+        .catch(err => {
+            const msg = "Could not retrieve playlist tracks from Spotify"
+            console.error(err)
+            return new Error(msg)
+        })
     
-    res.send("Got it.")
+    if (error)
+    {
+        return next(error)
+    }
+    
+    res.send(tracks)
 }
 
 module.exports = {

--- a/back-end/requests/get/get_generated_playlist.js
+++ b/back-end/requests/get/get_generated_playlist.js
@@ -1,0 +1,38 @@
+const axios = require("axios")
+let Group = require("../../models/groups.model")
+
+const get_generated_playlist = async (req, res, next) => {
+    let group_id = req.params.group_id
+    let user_id = req.user_id //user id of the requester
+    let members
+    let playlist_is_generated
+    let playlist_id
+    let error
+
+    error = await Group.findOne({_id: group_id})
+        .then(res => {
+            members = res.members
+            playlist_is_generated = res.playlist_is_generated
+            playlist_id = res.playlist_id
+            return false
+        })
+        .catch(err => {
+            const msg = "Error: could not find group"
+            console.log(msg)
+            console.error(err)
+            return new Error(msg)
+        })
+    
+    if (error)
+    {
+        return next(error)
+    }
+    
+    res.send("Got it.")
+}
+
+module.exports = {
+    get_generated_playlist: get_generated_playlist
+}
+
+//gets tracks from the spotify

--- a/back-end/routes/groups.js
+++ b/back-end/routes/groups.js
@@ -8,6 +8,7 @@ const get_members_and_owners = require("../requests/get/get_members_and_owners")
 const add_to_ban = require("../requests/put/add_to_ban");
 const kick_member = require("../requests/put/kick_member");
 const unban = require("../requests/put/unban");
+const get_generated_playlist = require("../requests/get/get_generated_playlist")
 const get_banned_members = require("../requests/get/get_banned_members");
 let get_pool = require("../requests/get/get_pool")
 
@@ -77,6 +78,10 @@ router.put("/unban/:group_id/:user_id/:bearer", unban.unban)
 //get pool endpoint
 router.use("/get_pool/:group_id/:bearer", user_id.get_user_id)
 router.get("/get_pool/:group_id/:bearer", get_pool.get_pool)
+
+//get generated playlist endpoint
+router.use("/get_generated_playlist/:group_id/:bearer", user_id.get_user_id)
+router.get("/get_generated_playlist/:group_id/:bearer", get_generated_playlist.get_generated_playlist)
 
 router.use("/playlist_id/:group_id/:bearer", user_id.get_user_id)
 router.get("/playlist_id/:group_id/:bearer", async (req, res, next) => {

--- a/front-end/src/pages/addSongs.js
+++ b/front-end/src/pages/addSongs.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Container, CssBaseline, AppBar, Toolbar } from "@material-ui/core";
 import Avatar from "@material-ui/core/avatar";
 import withStyles from "@material-ui/core/styles/withStyles";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import Button from "@material-ui/core/Button";
 import ArrowBackIosIcon from "@material-ui/icons/ArrowBackIos";
 import { Typography, Card, CardContent } from "@material-ui/core";
@@ -26,6 +26,10 @@ import _ from "lodash";
 
 const AddSongs = (props) => {
   let history = useHistory();
+  let location = useLocation()
+  let state = location.state
+  let group_id = state.id
+  let playlist_id = state.generated_playlist_id
   const { classes } = props;
   const [uiLoading, setuiLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
@@ -44,6 +48,13 @@ const AddSongs = (props) => {
         return prev;
       }, {});
   };
+
+  const handleGoBack = () => {
+    history.push({
+      pathname: "/generatedPlaylist/owner",
+      state:state
+    });
+  }
 
   const handleSearchTermChange = (term) => {
     let editedRes = [];
@@ -145,7 +156,7 @@ const AddSongs = (props) => {
         <AppBar className={classes.appBar}>
           <Toolbar className={classes.toolbar}>
             <Button
-              onClick={() => history.push("/generatedPlaylist/owner")}
+              onClick={handleGoBack}
               startIcon={<ArrowBackIosIcon className={classes.back} />}
             ></Button>
             <Typography variant="h5" className={classes.heading}>

--- a/front-end/src/pages/generatedPlaylist.js
+++ b/front-end/src/pages/generatedPlaylist.js
@@ -24,6 +24,7 @@ const Playlist = (props) => {
   let location = useLocation()
   let state = location.state
   let group_id = state.id
+  let playlist_id = state.generated_playlist_id
   const {
     match: { params },
   } = props;
@@ -53,7 +54,7 @@ const Playlist = (props) => {
     }
   };
 
-  const handleRemoveSong = (delIndex, event) => {
+  const handleRemoveSong = async (delIndex, event) => {
     event.stopPropagation(); //Prevents song from opening when remove button is pressed
 
     console.log("removing song with key ", delIndex);
@@ -61,6 +62,30 @@ const Playlist = (props) => {
     let song_id = songs[delIndex].id
     console.log("deleting song ", song_id)
 
+    //make delete request to spotify
+    let tracks = {"tracks": [{"uri":`spotify:track:${song_id}`}]} 
+    let URL = `https://api.spotify.com/v1/playlists/${playlist_id}/tracks`
+    let error = null
+
+    error = await axios({
+        method: "delete",
+        url: URL,
+        data: tracks,
+      })
+      .then(res => {
+        console.log(res)
+        return false
+      })
+      .catch(err => {
+        console.log("Error: could not remove track from playlist")
+        console.log(err)
+        return true
+      })
+    
+    if (error)
+    {
+      return
+    }
 
     let newSongs = []; //create a new array with every element except for the one we want to delete
     let curIndex = 0;

--- a/front-end/src/pages/generatedPlaylist.js
+++ b/front-end/src/pages/generatedPlaylist.js
@@ -17,14 +17,13 @@ import IconButton from "@material-ui/core/IconButton";
 import RemoveIcon from "@material-ui/icons/Remove";
 import styles from "../styles/generatedPlaylistStyles";
 import axios from "axios";
-import { set_authentication, is_expired } from "../components/authentication";
+import { set_authentication, is_expired, get_bearer } from "../components/authentication";
 
 const Playlist = (props) => {
   let history = useHistory();
   let location = useLocation()
   let state = location.state
   let group_id = state.id
-  let generated_playlist_id = state.generated_playlist_id
   const {
     match: { params },
   } = props;
@@ -58,6 +57,10 @@ const Playlist = (props) => {
     event.stopPropagation(); //Prevents song from opening when remove button is pressed
 
     console.log("removing song with key ", delIndex);
+    
+    let song_id = songs[delIndex].id
+    console.log("deleting song ", song_id)
+
 
     let newSongs = []; //create a new array with every element except for the one we want to delete
     let curIndex = 0;
@@ -81,11 +84,11 @@ const Playlist = (props) => {
     if (!isGuest && previousSongsRef.current === songs) {
       axios({
         method: "get",
-        url: `https://api.spotify.com/v1/playlists/${generated_playlist_id}/tracks`,
+        url: `http://localhost:5000/groups/get_generated_playlist/${group_id}/${get_bearer(localStorage)}`,
       })
         .then((res) => {
           setSongs(res.data.songs);
-          // console.log(res.data[0].songs);
+          console.log(res.data.songs);
           setuiLoading(false);
         })
         .catch((err) => console.log(err));

--- a/front-end/src/pages/generatedPlaylist.js
+++ b/front-end/src/pages/generatedPlaylist.js
@@ -41,16 +41,23 @@ const Playlist = (props) => {
 
   const handleAddMusic = () => {
     console.log("add songs");
-    history.push("/addSongs");
+    history.push({
+      pathname: "/addSongs",
+      state:state
+    });
   };
 
   const handleGoBack = () => {
     if (isOwner) {
-      history.push("/groupMenuOwner/generated");
-    } else if (isGuest) {
-      history.push("/groupMenuGuest/generated");
+      history.push({
+        pathname: "/groupMenuOwner/generated",
+        state: state
+      });
     } else {
-      history.push("/groupMenu/generated");
+      history.push({
+        pathname: "/groupMenu/generated",
+        state: state
+      });
     }
   };
 
@@ -63,6 +70,10 @@ const Playlist = (props) => {
     console.log("deleting song ", song_id)
 
     //make delete request to spotify
+    if (is_expired(localStorage)){ //first check that the bearer has not yet expired first
+      return history.push("/");
+    }
+
     let tracks = {"tracks": [{"uri":`spotify:track:${song_id}`}]} 
     let URL = `https://api.spotify.com/v1/playlists/${playlist_id}/tracks`
     let error = null

--- a/front-end/src/pages/home.js
+++ b/front-end/src/pages/home.js
@@ -226,7 +226,7 @@ const Home = (props) => {
       //Follow the playlist
       axios({
         method: "put",
-        url: `https://api.spotify.com/v1/playlists/${currGroup.id}/followers`,
+        url: `https://api.spotify.com/v1/playlists/${currGroup.generated_playlist_id}/followers`,
         data: {
           public: true,
         },


### PR DESCRIPTION
I added an endpoint on the backend (GET localhost:5000/groups/get_generated_playlist/:group_id/:bearer) to get this accomplished. You can view the generated playlist on any group where it's already been generated. I also added the ability to delete songs from the playlist.

To test this, you can create a group, add a few of your playlists to it, and then go back to the group menu and press "Generate Playlist". Then, that box should change to "View Generated Playlist", which you can click. All the songs should come up. Please test that deleting songs works as well.