### PR TITLE
Added Back-end URI to the ./front-end/.env file, added FRONT_END_URI to back-end/.env file , implemented these where necessary, fixed CORS errors on addMyMusic page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ typings/
 ## Jekyll artifacts
 **/.jekyll-cache
 **/_site/
+
+## pm2
+
+ecosystem.config.js

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -30,6 +30,8 @@ mongoose.connect(uri, {
   useUnifiedTopology: true,
 });
 
+let front_end_uri = process.env.FRONT_END_URI
+
 const connection = mongoose.connection;
 connection.once("open", () => {
   console.log("MongoDB connection established");
@@ -54,10 +56,8 @@ const usersRouter = require("./routes/users");
 app.use("/groups", groupsRouter);
 app.use("/users", usersRouter);
 
-// This code disables CORS, it may be necessary for debugging.
-//***We should remove this in the final version***
 app.use((req, res, next) => {
-  res.header("Access-Control-Allow-Origin", "YOUR-DOMAIN.TLD"); // update to match the domain you will make the request from
+  res.header("Access-Control-Allow-Origin", front_end_uri); // update to match the domain you will make the request from
   res.header(
     "Access-Control-Allow-Headers",
     "Origin, X-Requested-With, Content-Type, Accept"

--- a/back-end/test/add_to_pool.js
+++ b/back-end/test/add_to_pool.js
@@ -20,6 +20,7 @@ const run_add_to_pool_tests = async bearer => {
     before(async () => {
       //connect to MongoDB
       const uri = process.env.ATLAS_URI;
+      const back_end_uri = process.env.BACK_END_URI
       await mongoose.connect(uri, {
         keepAlive: true,
         useNewUrlParser: true,
@@ -127,7 +128,7 @@ const run_add_to_pool_tests = async bearer => {
       it('can add to pool', async () => {
         const playlist_id = sample_playlist_id 
         let status_code
-        let passed = await axios.put(`http://localhost:5000/groups/add_to_pool/${group_id}/${playlist_id}/${bearer}`) 
+        let passed = await axios.put(`${back_end_uri}/groups/add_to_pool/${group_id}/${playlist_id}/${bearer}`) 
           .then((res) => {
             status_code = res.status
           })
@@ -142,7 +143,7 @@ const run_add_to_pool_tests = async bearer => {
       it('can not add the same playlist twice', async () => {
         const playlist_id = sample_playlist_id 
 
-        let passed = await axios.put(`http://localhost:5000/groups/add_to_pool/${group_id}/${playlist_id}/${bearer}`) 
+        let passed = await axios.put(`${back_end_uri}/groups/add_to_pool/${group_id}/${playlist_id}/${bearer}`) 
           .then((res) => {
             status_code = res.status
             return true
@@ -161,7 +162,7 @@ const run_add_to_pool_tests = async bearer => {
         //note that this assumes the add_to_pool test passed
         const playlist_id = sample_playlist_id 
         let status_code
-        let passed = await axios.delete(`http://localhost:5000/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
+        let passed = await axios.delete(`${back_end_uri}/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
           .then((res) => {
             status_code = res.status
           })
@@ -177,7 +178,7 @@ const run_add_to_pool_tests = async bearer => {
         const playlist_id = sample_playlist_id 
         let status_code
         let error = null
-        let passed = await axios.delete(`http://localhost:5000/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
+        let passed = await axios.delete(`${back_end_uri}/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
           .then((res) => {
             status_code = res.status
           })
@@ -193,7 +194,7 @@ const run_add_to_pool_tests = async bearer => {
 
         let status_code
         let error = null
-        let passed = await axios.delete(`http://localhost:5000/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
+        let passed = await axios.delete(`${back_end_uri}/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
           .then((res) => {
             status_code = res.status
           })
@@ -217,7 +218,7 @@ const run_add_to_pool_tests = async bearer => {
         const playlist_id = other_user_sample_playlist_two
         let status_code
         let error = null
-        let passed = await axios.delete(`http://localhost:5000/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
+        let passed = await axios.delete(`${back_end_uri}/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
           .then((res) => {
             status_code = res.status
           })

--- a/back-end/test/add_to_pool.js
+++ b/back-end/test/add_to_pool.js
@@ -12,6 +12,8 @@ const set_authentication = require("../requests/other/authentication").set_authe
 const sample_playlist_id = "3PLPVWNT4CMjqSLpoRThxf" //note, as this is hardcoded, if the playlist is deleted this test will fail! I don't plan on deleting it, but I ever do accidentally, please change the playlist id here
 const other_user_sample_playlist_one = "26HeHZSvi7Q9BmRhxJxwt9"
 const other_user_sample_playlist_two = "76bxZcSKj8D5lFnc2BgtWd"
+require("dotenv").config();
+
 let user_id = ""
 const run_add_to_pool_tests = async bearer => {
  //Testing for add_to_pool endpoint
@@ -20,7 +22,6 @@ const run_add_to_pool_tests = async bearer => {
     before(async () => {
       //connect to MongoDB
       const uri = process.env.ATLAS_URI;
-      const back_end_uri = process.env.REACT_APP_BACK_END_URI
       await mongoose.connect(uri, {
         keepAlive: true,
         useNewUrlParser: true,
@@ -128,7 +129,7 @@ const run_add_to_pool_tests = async bearer => {
       it('can add to pool', async () => {
         const playlist_id = sample_playlist_id 
         let status_code
-        let passed = await axios.put(`${back_end_uri}/groups/add_to_pool/${group_id}/${playlist_id}/${bearer}`) 
+        let passed = await axios.put(`http://localhost:5000/groups/add_to_pool/${group_id}/${playlist_id}/${bearer}`) 
           .then((res) => {
             status_code = res.status
           })
@@ -143,7 +144,7 @@ const run_add_to_pool_tests = async bearer => {
       it('can not add the same playlist twice', async () => {
         const playlist_id = sample_playlist_id 
 
-        let passed = await axios.put(`${back_end_uri}/groups/add_to_pool/${group_id}/${playlist_id}/${bearer}`) 
+        let passed = await axios.put(`http://localhost:5000/groups/add_to_pool/${group_id}/${playlist_id}/${bearer}`) 
           .then((res) => {
             status_code = res.status
             return true
@@ -162,7 +163,7 @@ const run_add_to_pool_tests = async bearer => {
         //note that this assumes the add_to_pool test passed
         const playlist_id = sample_playlist_id 
         let status_code
-        let passed = await axios.delete(`${back_end_uri}/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
+        let passed = await axios.delete(`http://localhost:5000/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
           .then((res) => {
             status_code = res.status
           })
@@ -178,7 +179,7 @@ const run_add_to_pool_tests = async bearer => {
         const playlist_id = sample_playlist_id 
         let status_code
         let error = null
-        let passed = await axios.delete(`${back_end_uri}/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
+        let passed = await axios.delete(`http://localhost:5000/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
           .then((res) => {
             status_code = res.status
           })
@@ -194,7 +195,7 @@ const run_add_to_pool_tests = async bearer => {
 
         let status_code
         let error = null
-        let passed = await axios.delete(`${back_end_uri}/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
+        let passed = await axios.delete(`http://localhost:5000/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
           .then((res) => {
             status_code = res.status
           })
@@ -218,7 +219,7 @@ const run_add_to_pool_tests = async bearer => {
         const playlist_id = other_user_sample_playlist_two
         let status_code
         let error = null
-        let passed = await axios.delete(`${back_end_uri}/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
+        let passed = await axios.delete(`http://localhost:5000/groups/remove_from_pool/${group_id}/${playlist_id}/${bearer}`) 
           .then((res) => {
             status_code = res.status
           })

--- a/back-end/test/index.js
+++ b/back-end/test/index.js
@@ -87,7 +87,7 @@ describe("Check user info", async () => {
       let status_code;
 
       let passed = await axios
-        .get(`http://localhost:5000/groups/id/${group}`)
+        .get(`${back_end_uri}/groups/id/${group}`)
         .then((res) => {
           status_code = res.status;
         })
@@ -104,7 +104,7 @@ describe("Check user info", async () => {
     it("can add a new user", async () => {
       let status_code;
       let passed = await axios
-        .post(`http://localhost:5000/users/add`, {
+        .post(`${back_end_uri}/users/add`, {
           username: "dk3730",
         })
         .then((res) => {

--- a/back-end/test/index.js
+++ b/back-end/test/index.js
@@ -12,9 +12,7 @@ const mongoose = require("mongoose");
 const run_add_to_pool_tests = require("./add_to_pool.js").run_add_to_pool_tests
 const set_authentication = require("../requests/other/authentication").set_authentication
 
-
 require("dotenv").config();
-const back_end_uri = process.env.REACT_APP_BACK_END_URI
 
 const bearer = process.env.npm_config_bearer
 if (!bearer)
@@ -71,7 +69,7 @@ describe("Check user info", async () => {
       const user = "denniskuzminer"; //note, as this is hardcoded,
       let status_code;
       let passed = await axios
-        .get(`back_end_uri/groups/me/${user}`)
+        .get(`http://localhost:5000/groups/me/${user}`)
         .then((res) => {
           status_code = res.status;
         })
@@ -88,7 +86,7 @@ describe("Check user info", async () => {
       let status_code;
 
       let passed = await axios
-        .get(`${back_end_uri}/groups/id/${group}`)
+        .get(`http://localhost:5000/groups/id/${group}`)
         .then((res) => {
           status_code = res.status;
         })
@@ -105,7 +103,7 @@ describe("Check user info", async () => {
     it("can add a new user", async () => {
       let status_code;
       let passed = await axios
-        .post(`${back_end_uri}/users/add`, {
+        .post(`http://localhost:5000/users/add`, {
           username: "dk3730",
         })
         .then((res) => {

--- a/back-end/test/index.js
+++ b/back-end/test/index.js
@@ -14,6 +14,7 @@ const set_authentication = require("../requests/other/authentication").set_authe
 
 
 require("dotenv").config();
+const back_end_uri = process.env.REACT_APP_BACK_END_URI
 
 const bearer = process.env.npm_config_bearer
 if (!bearer)
@@ -70,7 +71,7 @@ describe("Check user info", async () => {
       const user = "denniskuzminer"; //note, as this is hardcoded,
       let status_code;
       let passed = await axios
-        .get(`http://localhost:5000/groups/me/${user}`)
+        .get(`back_end_uri/groups/me/${user}`)
         .then((res) => {
           status_code = res.status;
         })

--- a/front-end/src/components/playlistComponent.js
+++ b/front-end/src/components/playlistComponent.js
@@ -13,6 +13,8 @@ import styles from "../styles/playlistComponentStyles.js";
 import {get_bearer, set_authentication} from "../components/authentication"
 import axios from "axios"
 
+const back_end_uri = process.env.BACK_END_URI
+
 const pool_has_playlist = (pool, playlist_id) => {
   for (let i = 0; i < pool.length; i++)
   {
@@ -37,7 +39,7 @@ const pressButton = (event, added, setAdded, playlist, group_id, buttonEnabled, 
     axios(
       {
         method: "put",
-        url: `http://localhost:5000/groups/add_to_pool/${group_id}/${playlist_id}/${get_bearer(localStorage)}`,
+        url: `${back_end_uri}/groups/add_to_pool/${group_id}/${playlist_id}/${get_bearer(localStorage)}`,
       }
     )
       .then(res => {
@@ -53,7 +55,7 @@ const pressButton = (event, added, setAdded, playlist, group_id, buttonEnabled, 
     //should actually remove the group
     axios({
       method: "delete",
-      url: `http://localhost:5000/groups/remove_from_pool/${group_id}/${playlist_id}/${get_bearer(localStorage)}`
+      url: `${back_end_uri}/groups/remove_from_pool/${group_id}/${playlist_id}/${get_bearer(localStorage)}`
     })
       .then(res => {
         setAdded(false);

--- a/front-end/src/components/playlistComponent.js
+++ b/front-end/src/components/playlistComponent.js
@@ -13,7 +13,8 @@ import styles from "../styles/playlistComponentStyles.js";
 import {get_bearer, set_authentication} from "../components/authentication"
 import axios from "axios"
 
-const back_end_uri = process.env.BACK_END_URI
+require("dotenv").config();
+let back_end_uri = process.env.REACT_APP_BACK_END_URI
 
 const pool_has_playlist = (pool, playlist_id) => {
   for (let i = 0; i < pool.length; i++)
@@ -71,6 +72,7 @@ const pressButton = (event, added, setAdded, playlist, group_id, buttonEnabled, 
 };
 
 const Playlist = (props) => {
+  
   const playlist = props.playlist;
   const group_id = props.group_id
   const pool = props.pool

--- a/front-end/src/pages/addMyMusic.js
+++ b/front-end/src/pages/addMyMusic.js
@@ -16,6 +16,9 @@ import Playlist from "../components/playlistComponent.js";
 
 import styles from "../styles/addMyMusicStyles.js";
 
+require("dotenv").config();
+const back_end_uri = process.env.REACT_APP_BACK_END_URI
+
 const backupPlaylists = [
     {
         name: "My Playlist",
@@ -84,7 +87,7 @@ const AddMyMusic = (props) => {
         let bearer = get_bearer(localStorage)
         axios({
             method: "get",
-            url: `http://localhost:5000/user_playlists/${bearer}/false` //true indicates we want playlists attached
+            url: `${back_end_uri}/user_playlists/${bearer}/false` //true indicates we want playlists attached
         }) //makes a call to the back-end
             .then((response) => {  
                 if (playlists === "unset")
@@ -93,7 +96,7 @@ const AddMyMusic = (props) => {
                   //get and set the pool
                   axios({
                     method: "get",
-                    url: `http://localhost:5000/groups/get_pool/${group_id}/${bearer}`
+                    url: `${back_end_uri}/groups/get_pool/${group_id}/${bearer}`
                   })
                     .then(poolRes => { 
                       setPool(poolRes.data.pool);

--- a/front-end/src/pages/addMyMusic.js
+++ b/front-end/src/pages/addMyMusic.js
@@ -75,7 +75,6 @@ const AddMyMusic = (props) => {
   }
 
   useEffect(() => {
-
     if (is_expired(localStorage))
     {
       return history.push("/"); 

--- a/front-end/src/pages/addSongs.js
+++ b/front-end/src/pages/addSongs.js
@@ -100,7 +100,7 @@ const AddSongs = (props) => {
     // }
     // axios({
     //   method: "get",
-    //   url: `http://localhost:5000/playlists/`,
+    //   url: `${back_end_uri}/playlists/`,
     // })
     //   .then((res) => {
     //     setSongs(res.data[0].songs);

--- a/front-end/src/pages/bannedMembers.js
+++ b/front-end/src/pages/bannedMembers.js
@@ -13,6 +13,9 @@ import {get_bearer, is_expired} from "../components/authentication.js"
 import Logout from "../components/logout";
 import axios from "axios"
 
+require("dotenv").config();
+const back_end_uri = process.env.REACT_APP_BACK_END_URI
+
 const BannedMembers = (props) => {
   let history = useHistory();
   let location = useLocation()
@@ -55,7 +58,7 @@ const BannedMembers = (props) => {
     {
         return history.push("/"); 
     } 
-    axios(`http://localhost:5000/groups/get_banned_members/${group_id}/${get_bearer(localStorage)}`)
+    axios(`${back_end_uri}/groups/get_banned_members/${group_id}/${get_bearer(localStorage)}`)
     .then(res => {
       console.log("res=",res)
       let newBannedMembers = []

--- a/front-end/src/pages/generatedPlaylist.js
+++ b/front-end/src/pages/generatedPlaylist.js
@@ -23,6 +23,9 @@ import {
   get_bearer,
 } from "../components/authentication";
 
+require("dotenv").config();
+const back_end_uri = process.env.REACT_APP_BACK_END_URI
+
 const Playlist = (props) => {
   let history = useHistory();
   let location = useLocation();
@@ -127,7 +130,7 @@ const Playlist = (props) => {
     if (!isGuest && previousSongsRef.current === songs) {
       axios({
         method: "get",
-        url: `http://localhost:5000/groups/get_generated_playlist/${group_id}/${get_bearer(
+        url: `${back_end_uri}/groups/get_generated_playlist/${group_id}/${get_bearer(
           localStorage
         )}`,
       })
@@ -141,7 +144,7 @@ const Playlist = (props) => {
             })
             .catch((err) => console.log(err));
           axios(
-            `http://localhost:5000/groups/get_members_and_owners/${group_id}/${get_bearer(
+            `${back_end_uri}/groups/get_members_and_owners/${group_id}/${get_bearer(
               localStorage
             )}`
           )

--- a/front-end/src/pages/groupmenu_owner.js
+++ b/front-end/src/pages/groupmenu_owner.js
@@ -25,6 +25,9 @@ import {
   is_expired,
 } from "../components/authentication.js";
 
+require("dotenv").config();
+const back_end_uri = process.env.REACT_APP_BACK_END_URI
+
 const GroupMenuOwner = (props) => {
   let location = useLocation();
   let state = location.state
@@ -56,7 +59,7 @@ const GroupMenuOwner = (props) => {
     })
   };
   const handleViewPlaylist = async () => {
-    let passed = await axios(`http://localhost:5000/groups/playlist_id/${group_id}/${get_bearer(localStorage)}`)
+    let passed = await axios(`${back_end_uri}/groups/playlist_id/${group_id}/${get_bearer(localStorage)}`)
       .then(res => {
           state.generated_playlist_id = res.data.generated_playlist_id
           return true
@@ -78,7 +81,7 @@ const GroupMenuOwner = (props) => {
   const handleGeneratePlaylist = () => {
     axios({
       method: "post",
-      url: `http://localhost:5000/generate_playlist/"new_playlist"/${group_id}/${get_bearer(localStorage)}`
+      url: `${back_end_uri}/generate_playlist/"new_playlist"/${group_id}/${get_bearer(localStorage)}`
     })
       .then(res => {
         setPlaylistGenerated(true);
@@ -134,7 +137,7 @@ const GroupMenuOwner = (props) => {
     setGroupName(location.state.name);
     setuiLoading(false);
     
-    axios(`http://localhost:5000/groups/playlist_is_generated/${group_id}/${get_bearer(localStorage)}`)
+    axios(`${back_end_uri}/groups/playlist_is_generated/${group_id}/${get_bearer(localStorage)}`)
       .then(res => {
         console.log("playlist_is_generated=",res.data.playlist_is_generated)
         setPlaylistGenerated(res.data.playlist_is_generated)

--- a/front-end/src/pages/home.js
+++ b/front-end/src/pages/home.js
@@ -39,6 +39,10 @@ const Home = (props) => {
   const [openConfirmLogout, setOpenConfirmLogout] = useState(false);
   const [myGroups, setMyGroups] = useState([]);
 
+  require("dotenv").config();
+  let back_end_uri 
+  back_end_uri = process.env.REACT_APP_BACK_END_URI
+
   let groups = [
     {
       name: "Work Buddies",
@@ -84,6 +88,7 @@ const Home = (props) => {
   };
 
   useEffect(() => {
+    
     const { setExpiryTime, history, location } = props;
     try {
       if (_.isEmpty(location.hash)) {
@@ -128,7 +133,7 @@ const Home = (props) => {
         setUserID(nameRes.data.id);
         axios({
           method: "get",
-          url: `http://localhost:5000/groups/me/${nameRes.data.id}`,
+          url: `${back_end_uri}/groups/me/${nameRes.data.id}`,
         })
           .then((response) => {
             response.data.forEach((playlist) => { //in this context "playlist" refers to a group.
@@ -178,7 +183,7 @@ const Home = (props) => {
       // console.log(groupName);
       await axios({
         method: "get",
-        url: `http://localhost:5000/groups/id/${groupName}`,
+        url: `${back_end_uri}/groups/id/${groupName}`,
       })
         .then((res) => {
           currGroup = res.data[0];
@@ -194,7 +199,7 @@ const Home = (props) => {
     if (groupName) {
       axios({
         method: "put",
-        url: `http://localhost:5000/groups/add_members/${groupName}/${userid}`,
+        url: `${back_end_uri}/groups/add_members/${groupName}/${userid}`,
       })
         .then((res) => {
           console.log(res);
@@ -260,7 +265,7 @@ const Home = (props) => {
           // Add the playlist to the DB
           axios({
             method: "post",
-            url: `http://localhost:5000/group/add`,
+            url: `${back_end_uri}/group/add`,
             data: { owners: userid, members: userid, href: res.data.href },
           })
             .then((res) => {
@@ -314,7 +319,7 @@ const Home = (props) => {
           // Add the playlist to the DB
           axios({
             method: "post",
-            url: `http://localhost:5000/groups/add`,
+            url: `${back_end_uri}/groups/add`,
             data: {
               owners: userid,
               members: userid,

--- a/front-end/src/pages/landing.js
+++ b/front-end/src/pages/landing.js
@@ -34,7 +34,7 @@ const Landing = (props) => {
     REACT_APP_CLIENT_ID,
     REACT_APP_AUTHORIZE_URL,
     REACT_APP_REDIRECT_URL,
-    BACK_END_URI
+    REACT_APP_BACK_END_URI
   } = process.env;
 
   const spotifyApi = new SpotifyWebApi();

--- a/front-end/src/pages/landing.js
+++ b/front-end/src/pages/landing.js
@@ -34,6 +34,7 @@ const Landing = (props) => {
     REACT_APP_CLIENT_ID,
     REACT_APP_AUTHORIZE_URL,
     REACT_APP_REDIRECT_URL,
+    BACK_END_URI
   } = process.env;
 
   const spotifyApi = new SpotifyWebApi();

--- a/front-end/src/pages/members.js
+++ b/front-end/src/pages/members.js
@@ -14,6 +14,9 @@ import styles from "../styles/membersStyles.js";
 import {get_bearer, is_expired} from "../components/authentication.js"
 
 const Members = (props) => {
+  require("dotenv").config();
+  let back_end_uri 
+  back_end_uri = process.env.REACT_APP_BACK_END_URI
   let history = useHistory();
   const { classes } = props;
   const [uiLoading, setuiLoading] = useState(true);
@@ -36,7 +39,7 @@ const Members = (props) => {
       return history.push("/"); 
     }
 
-    axios(`http://localhost:5000/groups/get_members_and_owners/${group_id}/${get_bearer(localStorage)}`)
+    axios(`${back_end_uri}/groups/get_members_and_owners/${group_id}/${get_bearer(localStorage)}`)
       .then(res => {
         console.log("res=",res)
         let new_memberlist = []

--- a/front-end/src/pages/membersOwner.js
+++ b/front-end/src/pages/membersOwner.js
@@ -15,6 +15,8 @@ import {get_bearer, is_expired} from "../components/authentication.js"
 import Logout from "../components/logout";
 
 const MembersOwner = (props) => {
+  let back_end_uri 
+  back_end_uri = process.env.REACT_APP_BACK_END_URI
   let history = useHistory();
   let location = useLocation()
   let state = location.state
@@ -52,7 +54,7 @@ const MembersOwner = (props) => {
       return history.push("/"); 
     }
 
-    axios(`http://localhost:5000/groups/get_members_and_owners/${group_id}/${get_bearer(localStorage)}`)
+    axios(`${back_end_uri}/groups/get_members_and_owners/${group_id}/${get_bearer(localStorage)}`)
       .then(res => {
         console.log("res=",res)
         let new_memberlist = []

--- a/front-end/src/pages/viewMusic.js
+++ b/front-end/src/pages/viewMusic.js
@@ -25,6 +25,9 @@ import axios from "axios";
 
 import styles from "../styles/viewMusicStyles";
 
+require("dotenv").config();
+const back_end_uri = process.env.REACT_APP_BACK_END_URI
+
 const ViewMusic = (props) => {
   let history = useHistory();
   let location = useLocation();
@@ -43,7 +46,7 @@ const ViewMusic = (props) => {
     set_authentication(localStorage, axios);
     axios({
       method: "get",
-      url: `http://localhost:5000/groups/get_pool/${state.id}/${get_bearer(
+      url: `${back_end_uri}/groups/get_pool/${state.id}/${get_bearer(
         localStorage
       )}`,
     })
@@ -116,7 +119,7 @@ const ViewMusic = (props) => {
     set_authentication(localStorage, axios);
     axios({
       method: "delete",
-      url: `http://localhost:5000/groups/remove_from_pool/${
+      url: `${back_end_uri}/groups/remove_from_pool/${
         location.state.id
       }/${playlist.id}/${get_bearer(localStorage)}`,
     })

--- a/front-end/src/pages/viewMusicOwner.js
+++ b/front-end/src/pages/viewMusicOwner.js
@@ -23,6 +23,9 @@ import {
 } from "../components/authentication.js";
 
 import styles from "../styles/viewMusicStyles";
+
+require("dotenv").config();
+const back_end_uri = process.env.REACT_APP_BACK_END_URI
 // import Logout from "../components/logout";
 
 const ViewMusicOwner = (props) => {
@@ -43,7 +46,7 @@ const ViewMusicOwner = (props) => {
     set_authentication(localStorage, axios);
     axios({
       method: "get",
-      url: `http://localhost:5000/groups/get_pool/${state.id}/${get_bearer(
+      url: `${back_end_uri}/groups/get_pool/${state.id}/${get_bearer(
         localStorage
       )}`,
     })
@@ -93,7 +96,7 @@ const ViewMusicOwner = (props) => {
     set_authentication(localStorage, axios);
     axios({
       method: "delete",
-      url: `http://localhost:5000/groups/remove_from_pool/${
+      url: `${back_end_uri}/groups/remove_from_pool/${
         location.state.id
       }/${playlist.id}/${get_bearer(localStorage)}`,
     })


### PR DESCRIPTION
Note: as Git does not track .env files, for this to work, you must add the following line to your ./front-end/.env file.
`REACT_APP_BACK_END_URI=http://localhost:5000`
You will also need to add the following to your ./back-end/.env file
`FRONT_END_URI = http://localhost:3000`

The reason for this addition is that on digitalocean, our front-end was not able to integrate with the back-end due to the fact that the back-end url we use for axios requests was hardcoded as "localhost:5000", whereas in reality our digitalocean front-end needs to access the IP address for the back-end. But if we were to hardcode in the IP address, our local version would no longer work independently of the deployed app. So the solution is to put it in the .env file, and define them differently between the server and our local machines.

I would just recommend testing any pages you can, and checking that the back-end chai tests are working.

Edit:

Note that I made a few changes to the back-end as well in the pull request, which should fix the need to enable CORS on your web browser. Basically, I realized that the thing we were doing to allow CORS in our back-end wasn't actually specifying what IP address was acceptable. I added a similar ENV variable, FRONT_END_URI, to the back-end, so we can specify it as localhost on our local machines, and the IP address on the remote server. 