### PR TITLE
Generate Playlist button can't be clicked twice in a row, removed test notifications, added regenerate button, changing the group name persists between pages.

### DIFF
--- a/front-end/src/pages/generatedPlaylist.js
+++ b/front-end/src/pages/generatedPlaylist.js
@@ -9,6 +9,7 @@ import { Typography, CardContent } from "@material-ui/core";
 import Box from "@material-ui/core/Box";
 
 import backgroundWhite from "../media/background_white.png";
+import Error from "../components/error";
 
 import Loading from "../components/loading";
 import Logout from "../components/logout";
@@ -44,12 +45,13 @@ const Playlist = (props) => {
   const [members, setMembers] = useState([]);
   let [isOwner, setIsOwner] = useState(params.userStatus === "owner"); //params.userStatus is whatever comes after /generatedPlaylist/ in the url
   let [isGuest, setIsGuest] = useState(params.userStatus === "guest");
+  const [refreshCount, setRefreshCount] = useState(0)
   const [songs, setSongs] = useState([]);
   const [playlistAvatar, setPlaylistAvatar] = useState("");
   const previousSongsRef = useRef(songs);
+  const [copied, setCopied] = useState("");
 
   const handleAddMusic = () => {
-    console.log("add songs");
     history.push({
       pathname: "/addSongs",
       state: state,
@@ -71,6 +73,60 @@ const Playlist = (props) => {
     }
   };
 
+  const refreshPage = () => {
+    setSongs([])
+    axios({
+      method: "get",
+      url: `${back_end_uri}/groups/get_generated_playlist/${group_id}/${get_bearer(
+        localStorage
+      )}`,
+    })
+      .then((res) => {
+        axios({
+          method: "get",
+          url: `https://api.spotify.com/v1/playlists/${location.state.generated_playlist_id}`,
+        })
+          .then((response) => {
+            setPlaylistAvatar(response.data.images[0].url);
+          })
+          .catch((err) => console.log(err));
+        axios(
+          `${back_end_uri}/groups/get_members_and_owners/${group_id}/${get_bearer(
+            localStorage
+          )}`
+        )
+          .then((res) => {
+            console.log(res);
+            setMembers(res.data.members);
+          })
+          .catch((err) => {
+            console.log(err);
+          });
+        res.data.songs.forEach((song) => {
+          axios({
+            method: "get",
+            url: `https://api.spotify.com/v1/tracks/${song.id}`,
+          })
+            .then((response) => {
+              setSongs((songs) => [
+                ...songs,
+                {
+                  artist: song.artist,
+                  id: song.id,
+                  title: song.title,
+                  image: response.data.album.images[0].url,
+                },
+              ]);
+            })
+            .catch((err) => console.log(err));
+        });
+      })
+      .then((res) => {
+        setuiLoading(false);
+      })
+      .catch((err) => console.log(err));
+  }
+
   const handleRequestRegeneration = () => {
     if (is_expired(localStorage)) {
       return history.push("/");
@@ -90,6 +146,29 @@ const Playlist = (props) => {
       });
 
   };
+
+  const handleRegeneratePlaylist = () => {
+    if (is_expired(localStorage)) {
+      return history.push("/");
+    }
+    axios({
+      method: "post",
+      url: `${back_end_uri}/generate_playlist/"new_playlist"/${group_id}/${get_bearer(
+        localStorage
+      )}`,
+    })
+      .then((res) => {
+        refreshPage()
+        // setuiLoading(false);
+      })
+      .catch((err) => {
+        setCopied(
+          "This error has occurred either because there are no songs in one or more of the playlists or because one or more of the playlists are not public. Please modify the playlist settings in Spotify."
+        );
+        // setuiLoading(false);
+        console.log("Error: could not generate playlist");
+      });
+  }
 
 
 
@@ -319,16 +398,32 @@ const Playlist = (props) => {
               </Typography>
             </center>
           </div>
+          <Error
+            error={copied}
+            setError={setCopied}
+            severity={copied.includes("error") ? "error" : "success"}
+          />
           <div className={classes.songContainer}>
             {isOwner && (
-              <div className={classes.buttonContainer}>
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={handleAddMusic}
-                >
-                  Add music
-                </Button>
+              <div>
+                <div className={classes.buttonContainer}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleAddMusic}
+                  >
+                    Add music
+                  </Button>
+                </div>
+                <div className={classes.buttonContainer}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleRegeneratePlaylist}
+                  >
+                    Regenerate playlist
+                  </Button>
+                </div>
               </div>
             )}
             {!isOwner && (

--- a/front-end/src/pages/groupmenu.js
+++ b/front-end/src/pages/groupmenu.js
@@ -157,8 +157,7 @@ const GroupMenu = (props) => {
             onClick={handleGenerateRequest}
           >
             <center>
-              Request Playlist generation (append '/generated' to url to
-              simulate owner generating new playlist)
+              Request Playlist generation
             </center>
           </Typography>
         </CardContent>

--- a/front-end/src/pages/groupmenu_owner.js
+++ b/front-end/src/pages/groupmenu_owner.js
@@ -82,6 +82,10 @@ const GroupMenuOwner = (props) => {
   };
   const handleGeneratePlaylist = () => {
     // setuiLoading(true);
+    if (is_expired(localStorage)) {
+      return history.push("/");
+    }
+    
     axios({
       method: "post",
       url: `${back_end_uri}/generate_playlist/"new_playlist"/${group_id}/${get_bearer(

--- a/front-end/src/pages/groupmenu_owner.js
+++ b/front-end/src/pages/groupmenu_owner.js
@@ -40,7 +40,7 @@ const GroupMenuOwner = (props) => {
   const [playlistGenerated, setPlaylistGenerated] = useState(false);
   const [generateButtonEnabled, setGenerateButtonEnabled] = useState(false)
   const [copied, setCopied] = useState("");
-  const [firstRound, setFirstRound] = useState(true)
+  let firstRound = true;
 
   const handleViewAllMusic = () => {
     //console.log("You've clicked on view all music");
@@ -135,24 +135,11 @@ const GroupMenuOwner = (props) => {
         })
           .then((res) => {
             setGroupName(name);
+            state.name = name
           })
           .catch((err) => console.log(err));
       })
       .catch((err) => console.log(err));
-  };
-
-  const handleTestNotification = () => {
-    let notifMessage =
-      "A user within the group " +
-      groupName +
-      " has requested that you generate/regenerate the playlist for that group";
-    addNotification({
-      title: "User requested new playlist generation",
-      subtitle: "New playlist request",
-      message: notifMessage,
-      theme: "darkblue",
-      native: true,
-    });
   };
 
   useEffect(() => {
@@ -178,7 +165,7 @@ const GroupMenuOwner = (props) => {
           console.log(err);
         });
       setuiLoading(false);
-      setFirstRound(false);
+      firstRound = false
     }
   }, [
     history,
@@ -314,19 +301,6 @@ const GroupMenuOwner = (props) => {
             </CardContent>
           </Card>
           {playlistCard}
-          <Card
-            fullWidth
-            className={classes.cards}
-            onClick={handleTestNotification}
-          >
-            <CardContent style={{ marginBottom: "-10px" }}>
-              <Typography className={classes.cardText}>
-                <center>
-                  Test Notifications (not intended for final product)
-                </center>
-              </Typography>
-            </CardContent>
-          </Card>
         </div>
       </Container>
     );

--- a/front-end/src/pages/groupmenu_owner.js
+++ b/front-end/src/pages/groupmenu_owner.js
@@ -38,7 +38,9 @@ const GroupMenuOwner = (props) => {
   const [groupName, setGroupName] = useState("");
   const [openConfirmLogout, setOpenConfirmLogout] = useState(false);
   const [playlistGenerated, setPlaylistGenerated] = useState(false);
+  const [generateButtonEnabled, setGenerateButtonEnabled] = useState(false)
   const [copied, setCopied] = useState("");
+  const [firstRound, setFirstRound] = useState(true)
 
   const handleViewAllMusic = () => {
     //console.log("You've clicked on view all music");
@@ -85,7 +87,7 @@ const GroupMenuOwner = (props) => {
     if (is_expired(localStorage)) {
       return history.push("/");
     }
-    
+    setGenerateButtonEnabled(false)
     axios({
       method: "post",
       url: `${back_end_uri}/generate_playlist/"new_playlist"/${group_id}/${get_bearer(
@@ -102,6 +104,7 @@ const GroupMenuOwner = (props) => {
         );
         // setuiLoading(false);
         console.log("Error: could not generate playlist");
+        setGenerateButtonEnabled(true)
       });
   };
 
@@ -159,28 +162,35 @@ const GroupMenuOwner = (props) => {
     // get group id
     setGroupID(location.state.id);
     setGroupName(location.state.name);
-    setuiLoading(false);
 
-    axios(
-      `${back_end_uri}/groups/playlist_is_generated/${group_id}/${get_bearer(
-        localStorage
-      )}`
-    )
-      .then((res) => {
-        console.log("playlist_is_generated=", res.data.playlist_is_generated);
-        setPlaylistGenerated(res.data.playlist_is_generated);
-      })
-      .catch((err) => {
-        console.log(err);
-      });
+    if (firstRound)
+    {
+      axios(
+        `${back_end_uri}/groups/playlist_is_generated/${group_id}/${get_bearer(
+          localStorage
+        )}`
+      )
+        .then((res) => {
+          setPlaylistGenerated(res.data.playlist_is_generated);
+          setGenerateButtonEnabled(true)
+        })
+        .catch((err) => {
+          console.log(err);
+        });
+      setuiLoading(false);
+      setFirstRound(false);
+    }
   }, [
     history,
     playlistGenerated,
+    generateButtonEnabled,
     location.state.id,
     location.state,
     params.playlistGenerated,
     group_id,
   ]);
+
+  console.log("updating innards")
   if (playlistGenerated) {
     // Determines whether to show the user "view generated playlist" or "generate playlist"
     playlistCard = (
@@ -193,11 +203,18 @@ const GroupMenuOwner = (props) => {
       </Card>
     );
   } else {
+    let curClassName = classes.grayCards
+    let curOnClick = null
+    if (generateButtonEnabled)
+    {
+      curClassName = classes.cards
+      curOnClick = handleGeneratePlaylist
+    }
     playlistCard = (
       <Card
         fullWidth
-        className={classes.cards}
-        onClick={handleGeneratePlaylist}
+        className={curClassName}
+        onClick={curOnClick}
       >
         <CardContent style={{ marginBottom: "-10px" }}>
           <Typography className={classes.cardText}>
@@ -211,6 +228,7 @@ const GroupMenuOwner = (props) => {
   if (uiLoading === true) {
     return <Loading />;
   } else {
+    console.log("updating outtards")
     return (
       <Container component="main" maxWidth="xs">
         <CssBaseline />

--- a/front-end/src/styles/groupmenuStyles.js
+++ b/front-end/src/styles/groupmenuStyles.js
@@ -24,6 +24,15 @@ const styles = (theme) => ({
     },
     top: "10%",
   },
+  grayCards: {
+    marginTop: "10px",
+    boxShadow: "0 8px 18px -12px rgba(0,0,0,0.3)",
+    "&:hover": {
+      boxShadow: "0 16px 70px -12.125px rgba(0,0,0,0.3)",
+    },
+    top: "10%",
+    backgroundColor: "gray"
+  },
   flexCard: {
     display: "flex",
     flexDirection: "column",


### PR DESCRIPTION
Changes made:
- Can now regenerate the playlist from the generatedPlaylist owner page, and it will refresh
- Generate playlist button (on group menu) can not be clicked twice in a row. It will turn gray and not allow you to click it until the playlist is generated, or an error is encountered. Sorry for getting a bit sidetracked with this one.
- Removed test notifcations from group menu owner page
- Group name persists between pages now